### PR TITLE
Use readable IDs

### DIFF
--- a/app/src/Entity/Transport.php
+++ b/app/src/Entity/Transport.php
@@ -50,7 +50,7 @@ class Transport
         public readonly \DateTimeImmutable $startAt,
     ) {
         $this->travelers = new ArrayCollection();
-        $this->shortId = Shortid::generate(5)->serialize();
+        $this->shortId = Shortid::generate(5, readable: true)->serialize();
     }
 
     public function getDriver(): User


### PR DESCRIPTION
This avois ambiguous characters, like `B/8`, `0/O` or `I/l`.

The option is explained here: https://github.com/PUGX/shortid-php?tab=readme-ov-file#more-readable-strings

And the list of ambiguous characters is here: https://github.com/paragonie/RandomLib/blob/master/lib/RandomLib/Generator.php#L138